### PR TITLE
kernel: Use CPATH for including host headers

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -120,7 +120,7 @@ endif
 ifeq ($(HOST_OS),darwin)
   KERNEL_MAKE_FLAGS += HOSTCFLAGS="-I$(BUILD_TOP)/external/elfutils/libelf -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib"
 else
-  KERNEL_MAKE_FLAGS += HOSTCFLAGS="-I/usr/include -I/usr/include/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu -L/usr/lib64"
+  KERNEL_MAKE_FLAGS += CPATH="/usr/include:/usr/include/x86_64-linux-gnu" HOSTCFLAGS="-L/usr/lib/x86_64-linux-gnu -L/usr/lib64"
 endif
 
 ifneq ($(TARGET_KERNEL_ADDITIONAL_FLAGS),)


### PR DESCRIPTION
* Fixes build on distros where CAP_LAST_CAP @ /usr/include/linux/capability.h
  doesn't match target device kernel src.

Change-Id: Iafdf9694fd165c83b22bd95df95e940ecceb0fdd
Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>